### PR TITLE
Dashboard Performance for Large Numbers of Events

### DIFF
--- a/app/controllers/solid_cache_dashboard/dashboard_controller.rb
+++ b/app/controllers/solid_cache_dashboard/dashboard_controller.rb
@@ -1,40 +1,57 @@
 module SolidCacheDashboard
   class DashboardController < ApplicationController
     def index
-      @cache_entries = SolidCacheDashboard.decorate(SolidCache::Entry.all)
-      @cache_events = SolidCacheDashboard.decorate(SolidCacheDashboard::CacheEvent.all)
+      @chart_period = params[:chart_period] || '30m'
+      @period_start = Time.current - chart_period_duration[@chart_period]
+
+      @cache_entries = SolidCacheDashboard.decorate(SolidCache::Entry.where(created_at: @period_start..))
+      @cache_events = SolidCacheDashboard.decorate(SolidCacheDashboard::CacheEvent.where(created_at: @period_start..))
       load_charts
     end
 
     private
 
+    def chart_period_duration
+      {
+        '15m' => 15.minutes,
+        '30m' => 30.minutes,
+        '1h' => 1.hour,
+        '3h' => 3.hours,
+        '6h' => 6.hours,
+        '12h' => 12.hours,
+        '1d' => 1.day,
+        '3d' => 3.days,
+        '1w' => 1.week
+      }
+    end
+
     def load_charts
-      case params[:chart_period] || "30m"
-      when "15m"
+      case @chart_period
+      when '15m'
         n = 1
         last = 15
-      when "30m"
+      when '30m'
         n = 1
         last = 30
-      when "1h"
+      when '1h'
         n = 2
         last = 30
-      when "3h"
+      when '3h'
         n = 6
         last = 30
-      when "6h"
+      when '6h'
         n = 12
         last = 30
-      when "12h"
+      when '12h'
         n = 20
         last = 36
-      when "1d"
+      when '1d'
         n = 30
         last = 48
-      when "3d"
+      when '3d'
         n = 90 # 1.5 hours
         last = 48
-      when "1w"
+      when '1w'
         n = 180 # 3 hours
         last = 56
       else
@@ -44,24 +61,40 @@ module SolidCacheDashboard
 
       @charts = [
         {
-          name: "Hits",
-          data: SolidCacheDashboard::CacheEvent.hits.group_by_minute(:created_at, last: last, n: n).count,
-          color: "#23C55E"
+          name: 'Hits',
+          data: SolidCacheDashboard::CacheEvent
+            .where(created_at: @period_start..)
+            .hits
+            .group_by_minute(:created_at, last: last, n: n)
+            .count,
+          color: '#23C55E'
         },
         {
-          name: "Misses",
-          data: SolidCacheDashboard::CacheEvent.misses.group_by_minute(:created_at, last: last, n: n).count,
-          color: "#FBBF26"
+          name: 'Misses',
+          data: SolidCacheDashboard::CacheEvent
+            .where(created_at: @period_start..)
+            .misses
+            .group_by_minute(:created_at, last: last, n: n)
+            .count,
+          color: '#FBBF26'
         },
         {
-          name: "Writes",
-          data: SolidCacheDashboard::CacheEvent.writes.group_by_minute(:created_at, last: last, n: n).count,
-          color: "#38BDF8"
+          name: 'Writes',
+          data: SolidCacheDashboard::CacheEvent
+            .where(created_at: @period_start..)
+            .writes
+            .group_by_minute(:created_at, last: last, n: n)
+            .count,
+          color: '#38BDF8'
         },
         {
-          name: "Deletes",
-          data: SolidCacheDashboard::CacheEvent.deletes.group_by_minute(:created_at, last: last, n: n).count,
-          color: "#F04444"
+          name: 'Deletes',
+          data: SolidCacheDashboard::CacheEvent
+            .where(created_at: @period_start..)
+            .deletes
+            .group_by_minute(:created_at, last: last, n: n)
+            .count,
+          color: '#F04444'
         }
       ]
     end

--- a/app/controllers/solid_cache_dashboard/dashboard_controller.rb
+++ b/app/controllers/solid_cache_dashboard/dashboard_controller.rb
@@ -1,11 +1,13 @@
 module SolidCacheDashboard
   class DashboardController < ApplicationController
     def index
-      @chart_period = params[:chart_period] || '30m'
+      @chart_period = params[:chart_period].presence || '30m'
       @period_start = Time.current - chart_period_duration[@chart_period]
 
       @cache_entries = SolidCacheDashboard.decorate(SolidCache::Entry.where(created_at: @period_start..))
       @cache_events = SolidCacheDashboard.decorate(SolidCacheDashboard::CacheEvent.where(created_at: @period_start..))
+      @recent_cache_entries = SolidCacheDashboard.decorate(SolidCache::Entry.order(:created_at).limit(5))
+      @recent_cache_events = SolidCacheDashboard.decorate(SolidCacheDashboard::CacheEvent.order(:created_at).limit(5))
       load_charts
     end
 

--- a/app/views/solid_cache_dashboard/application/_navbar.html.erb
+++ b/app/views/solid_cache_dashboard/application/_navbar.html.erb
@@ -17,7 +17,7 @@
       <div class="hidden sm:ml-6 sm:flex sm:items-center">
         <% if current_page?(controller: 'dashboard', action: 'index') %>
               <%= form_with url: root_path, method: :get, class: "flex gap-1.5 items-center" do |form| %>
-          <%= form.hidden_field :chart_period %>
+          <%= form.hidden_field :chart_period, value: params[:chart_period] %>
 
           <!-- Refresh icon with size-4 and text-muted-foreground class -->
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-4 text-muted-foreground">

--- a/app/views/solid_cache_dashboard/dashboard/index.html.erb
+++ b/app/views/solid_cache_dashboard/dashboard/index.html.erb
@@ -75,7 +75,7 @@
       <div>
         <div class="inline-flex rounded-md shadow-xs">
           <% ["30m", "1h", "3h", "6h", "12h", "1d"].each do |period| %>
-            <%= link_to period.upcase, root_path(chart_period: period), class: "relative inline-flex items-center px-3 py-2 text-sm font-medium #{params[:chart_period] == period ? 'bg-zinc-100 dark:bg-secondary text-zinc-700 dark:text-white' : 'bg-white dark:bg-background text-zinc-500 dark:text-zinc-400 hover:bg-zinc-50 dark:hover:bg-secondary'} border border-zinc-300 dark:border-zinc-600" %>
+            <%= link_to period.upcase, root_path(chart_period: period), class: "relative inline-flex items-center px-3 py-2 text-sm font-medium #{@chart_period == period ? 'bg-zinc-100 dark:bg-secondary text-zinc-700 dark:text-white' : 'bg-white dark:bg-background text-zinc-500 dark:text-zinc-400 hover:bg-zinc-50 dark:hover:bg-secondary'} border border-zinc-300 dark:border-zinc-600" %>
           <% end %>
         </div>
       </div>

--- a/app/views/solid_cache_dashboard/dashboard/index.html.erb
+++ b/app/views/solid_cache_dashboard/dashboard/index.html.erb
@@ -102,7 +102,7 @@
             </tr>
           </thead>
           <tbody class="bg-white dark:bg-background divide-y divide-zinc-200 dark:divide-zinc-700">
-            <% @cache_entries.take(5).each do |entry| %>
+            <% @recent_cache_entries.each do |entry| %>
               <tr>
                 <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-zinc-900 dark:text-white truncate max-w-[200px]">
                   <%= link_to entry.key, cache_entry_path(entry.key_hash), class: "hover:underline" %>
@@ -139,7 +139,7 @@
             </tr>
           </thead>
           <tbody class="bg-white dark:bg-background divide-y divide-zinc-200 dark:divide-zinc-700">
-            <% @cache_events.take(5).each do |event| %>
+            <% @recent_cache_events.each do |event| %>
               <tr>
                 <td class="px-6 py-4 whitespace-nowrap text-sm text-zinc-500 dark:text-zinc-400">
                   <%= badge event.event_type.to_s.capitalize, event.color %>


### PR DESCRIPTION
Hi Andrea! 👋🏻 

If/when the SolidCacheDashboard::CacheEvent table grows to a certain size, performance eventually plummets.

This attempts to ensure that the dashboard loads only the relevant records to avoid this.

Note that the counts are also constrained to the selected period - this seems appropriate to me, but perhaps the more complete counts are actually intended?

I believe this will resolve Issue #2.